### PR TITLE
Use github API to determine default branch

### DIFF
--- a/pkg/api/github.go
+++ b/pkg/api/github.go
@@ -8,11 +8,11 @@ import (
 	"strconv"
 	"strings"
 
+	gh "github.com/adevinta/maiao/pkg/github"
+	"github.com/adevinta/maiao/pkg/log"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/google/go-github/v40/github"
 	"github.com/sirupsen/logrus"
-	gh "github.com/adevinta/maiao/pkg/github"
-	"github.com/adevinta/maiao/pkg/log"
 )
 
 // GitHub implements the PullRequester interface allowing to create pull requests for a given repository
@@ -102,6 +102,15 @@ func (g *GitHub) Update(ctx context.Context, pr *PullRequest, options PullReques
 		ID:  strconv.Itoa(*p.Number),
 		URL: *p.URL,
 	}, err
+}
+
+// DefaultBranch returns the default branch of the remote repository
+func (g *GitHub) DefaultBranch(ctx context.Context) string {
+	repo, _, err := g.Repositories.Get(ctx, g.Owner, g.Repository)
+	if err != nil {
+		return ""
+	}
+	return repo.GetDefaultBranch()
 }
 
 // LinkedTopicIssues returns the search URL for linked issues

--- a/pkg/api/pullRequester.go
+++ b/pkg/api/pullRequester.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 
+	"github.com/adevinta/maiao/pkg/log"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/sirupsen/logrus"
-	"github.com/adevinta/maiao/pkg/log"
 )
 
 // PullRequester defines the interface to implement to handle pull requests
@@ -17,6 +17,7 @@ type PullRequester interface {
 	// Ensure ensures one and only one pull request exists for the given head
 	Ensure(context.Context, PullRequestOptions) (*PullRequest, bool, error)
 	LinkedTopicIssues(topic string) string
+	DefaultBranch(context.Context) string
 }
 
 // PullRequestOptions are the options available to create or update a pull request

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -11,12 +11,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/adevinta/maiao/pkg/system"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/storer"
-	"github.com/adevinta/maiao/pkg/system"
 )
 
 const (


### PR DESCRIPTION
Context
---

In newer repositories, the default branch is now main instead of master.

Problem
---

In the current implementation, maiao is not aware of the github settings
and is restricted to the local ones, that may mismatch.
This causes a `reference not found` error.

Solution
---

Update the pull requester interface to allow retrieving the repository
settings and determine the relevant default branch
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Skip github upsert integration tests when permission is denied (#3)
</summary>
Context
---

Since we have opensourced maiao, the test repository is running in
github.com. Not all integrations and developments have access to this
integration repository, resulting to test failing.
This is particularly the case within GitHub codespaces.

Goal
---

Make sure tests passes when developing maiao under github codespaces
</details>
<details>
<summary>
Ensure git https calls are authenticated. (#4)
</summary>
Context
---

When moving to github.com and developing with codespaces, we find out
that the use of https endpoint is not completely supported by go-git.
Specially, go-git would not call the relevant git credential helper to
inject the required authentication.

Goal
---

Make sure git review calls done with https endpoints works
</details>
</details>
</details>