### PR TITLE
Skip github upsert integration tests when permission is denied

### DIFF
--- a/pkg/api/github_test.go
+++ b/pkg/api/github_test.go
@@ -314,6 +314,14 @@ func TestGitHubUpsert(t *testing.T) {
 		Tree:    rc.Commit.Tree,
 		Parents: rc.Parents,
 	})
+	if err != nil {
+		if ghError, ok := err.(*github.ErrorResponse); ok {
+			if ghError.Response.StatusCode == http.StatusForbidden {
+				t.Skipf("not enough permissions to run this check: %v", err)
+				return
+			}
+		}
+	}
 	require.NoError(t, err)
 	require.NotNil(t, c)
 	_, _, err = gh.Git.CreateRef(context.Background(), "adevinta", "maiao-tests", &github.Reference{


### PR DESCRIPTION
Context
---

Since we have opensourced maiao, the test repository is running in
github.com. Not all integrations and developments have access to this
integration repository, resulting to test failing.
This is particularly the case within GitHub codespaces.

Goal
---

Make sure tests passes when developing maiao under github codespaces
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Ensure git https calls are authenticated. (#4)
</summary>
Context
---

When moving to github.com and developing with codespaces, we find out
that the use of https endpoint is not completely supported by go-git.
Specially, go-git would not call the relevant git credential helper to
inject the required authentication.

Goal
---

Make sure git review calls done with https endpoints works
</details>
</details>
</details>