### PR TITLE
Ensure git https calls are authenticated.

### DIFF
--- a/pkg/credentials/auth_method.go
+++ b/pkg/credentials/auth_method.go
@@ -1,0 +1,28 @@
+package credentials
+
+import (
+	"net/http"
+
+	"github.com/adevinta/maiao/pkg/log"
+)
+
+type GitAuth struct {
+	Credentials CredentialGetter
+}
+
+func (a *GitAuth) SetAuth(r *http.Request) {
+	creds, err := a.Credentials.CredentialForHost(r.Host)
+	if err != nil || creds == nil {
+		log.Logger.WithField("host", r.Host).WithError(err).Infof("failed to find credentials")
+		return
+	}
+	r.SetBasicAuth(creds.Username, creds.Password)
+}
+
+func (a *GitAuth) Name() string {
+	return "auth from credentials"
+}
+
+func (a *GitAuth) String() string {
+	return "auth from credentials"
+}

--- a/pkg/credentials/git.go
+++ b/pkg/credentials/git.go
@@ -1,0 +1,52 @@
+package credentials
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+	"strings"
+)
+
+var run = realRun
+
+type runOpts struct {
+	path  string
+	args  []string
+	stdin string
+}
+
+func realRun(opts runOpts) (string, error) {
+	cmd := exec.Command(opts.path, opts.args...)
+	b := bytes.Buffer{}
+	cmd.Stdout = &b
+	if opts.stdin != "" {
+		cmd.Stdin = strings.NewReader(opts.stdin)
+	}
+	return b.String(), nil
+}
+
+type GitCredentials struct {
+	GitPath string
+}
+
+func (c *GitCredentials) CredentialForHost(host string) (*Credentials, error) {
+	// this should be better included with the actual git remotes.
+	out, err := run(runOpts{path: c.GitPath, args: []string{"credential", "fill"}, stdin: "protocol=https\nhost=" + host})
+	if err != nil {
+		return nil, err
+	}
+	if out != "" {
+		kv := map[string]string{}
+		for _, line := range strings.Split(out, "\n") {
+			keyAndValue := strings.SplitN(line, "=", 2)
+			if len(keyAndValue) == 2 {
+				kv[strings.TrimSpace(keyAndValue[0])] = strings.TrimSuffix(keyAndValue[1], "\n")
+			}
+		}
+		if _, ok := kv["password"]; ok {
+			return &Credentials{Username: kv["username"], Password: kv["password"]}, nil
+		}
+		return nil, errors.New("unable to find username and password from git credential")
+	}
+	return nil, errors.New("not found")
+}

--- a/pkg/credentials/git_test.go
+++ b/pkg/credentials/git_test.go
@@ -1,0 +1,66 @@
+package credentials
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGitCredentialsReturnsNoCredentialsWhenGitCommandFails(t *testing.T) {
+	t.Cleanup(func() {
+		run = realRun
+	})
+	run = func(opts runOpts) (string, error) {
+		return "", errors.New("test error")
+	}
+	gitCreds := GitCredentials{GitPath: "git"}
+	creds, err := gitCreds.CredentialForHost("test-host")
+	assert.Nil(t, creds)
+	assert.Error(t, err)
+}
+
+func TestGitCredentialsReturnsNoCredentialsWhenNoGitHelperIsProvided(t *testing.T) {
+	t.Cleanup(func() {
+		run = realRun
+	})
+	run = func(opts runOpts) (string, error) {
+		return "", nil
+	}
+	gitCreds := GitCredentials{GitPath: "git"}
+	creds, err := gitCreds.CredentialForHost("test-host")
+	assert.Nil(t, creds)
+	assert.Error(t, err)
+}
+
+func TestGitCredentialsReturnsCredentialsWhenCredentialsAreFound(t *testing.T) {
+	t.Cleanup(func() {
+		run = realRun
+	})
+	run = func(opts runOpts) (string, error) {
+		assert.Equal(t, "git", opts.path)
+		assert.Equal(t, []string{"credential", "fill"}, opts.args)
+		assert.Equal(t, "protocol=https\nhost=test-host", opts.stdin)
+		return "protocol=https\nhost=test-host\nusername=PersonalAccessToken\npassword=secure-password", nil
+	}
+	gitCreds := GitCredentials{GitPath: "git"}
+	creds, err := gitCreds.CredentialForHost("test-host")
+	assert.Equal(t, &Credentials{Username: "PersonalAccessToken", Password: "secure-password"}, creds)
+	assert.NoError(t, err)
+}
+
+func TestGitCredentialsReturnsNoCredentialsWhenCredentialsReturnNoPassowrd(t *testing.T) {
+	t.Cleanup(func() {
+		run = realRun
+	})
+	run = func(opts runOpts) (string, error) {
+		assert.Equal(t, "git", opts.path)
+		assert.Equal(t, []string{"credential", "fill"}, opts.args)
+		assert.Equal(t, "protocol=https\nhost=test-host", opts.stdin)
+		return "protocol=https\nhost=test-host\nusername=PersonalAccessToken\n", nil
+	}
+	gitCreds := GitCredentials{GitPath: "git"}
+	creds, err := gitCreds.CredentialForHost("test-host")
+	assert.Nil(t, creds)
+	assert.Error(t, err)
+}

--- a/pkg/github/credentials.go
+++ b/pkg/github/credentials.go
@@ -9,4 +9,5 @@ import (
 var DefaultCredentialGetter credentials.CredentialGetter = credentials.ChainCredentialGetter([]credentials.CredentialGetter{
 	&credentials.EnvToken{PasswordKey: "GITHUB_TOKEN"},
 	&credentials.Netrc{},
+	&credentials.GitCredentials{GitPath: "git"},
 })

--- a/pkg/maiao/review.go
+++ b/pkg/maiao/review.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 
 	"github.com/adevinta/maiao/pkg/api"
+	"github.com/adevinta/maiao/pkg/credentials"
 	lgit "github.com/adevinta/maiao/pkg/git"
+	gh "github.com/adevinta/maiao/pkg/github"
 	"github.com/adevinta/maiao/pkg/log"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
@@ -77,6 +79,7 @@ func Review(ctx context.Context, repo lgit.Repository, options ReviewOptions) er
 	log.ForContext(ctx).Debugf("fetching remote")
 	err = remote.Fetch(&git.FetchOptions{
 		RemoteName: options.Remote,
+		Auth:       &credentials.GitAuth{Credentials: gh.DefaultCredentialGetter},
 	})
 	if err != nil && err != git.NoErrAlreadyUpToDate {
 		log.ForContext(ctx).WithError(err).Error("failed to update git repository")
@@ -225,6 +228,7 @@ func sendPrs(ctx context.Context, repo lgit.Repository, options ReviewOptions, b
 	err = repo.Push(&git.PushOptions{
 		RemoteName: options.Remote,
 		RefSpecs:   refspecs,
+		Auth:       &credentials.GitAuth{Credentials: gh.DefaultCredentialGetter},
 		Force:      true,
 	})
 	if err != nil && err != git.NoErrAlreadyUpToDate {


### PR DESCRIPTION
Context
---

When moving to github.com and developing with codespaces, we find out
that the use of https endpoint is not completely supported by go-git.
Specially, go-git would not call the relevant git credential helper to
inject the required authentication.

Goal
---

Make sure git review calls done with https endpoints works
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>