### PR TITLE
Fix Commit message parser

### DIFF
--- a/pkg/git/message.go
+++ b/pkg/git/message.go
@@ -19,7 +19,7 @@ type Message struct {
 	Headers map[string]string
 }
 
-var headerRe = regexp.MustCompile("^([^:]+):([^:]+)$")
+var headerRe = regexp.MustCompile("^([^:]+):([^:/]+)$")
 
 // Parse parses a commit message string into a structured object
 func Parse(message string) *Message {

--- a/pkg/git/message_test.go
+++ b/pkg/git/message_test.go
@@ -16,13 +16,15 @@ And the body
 
 with multiple lines
 
+and a link http://maiao.foo
+
 Header : bla
 
 `
 
 	m := Parse(commitMessage)
 	assert.Equal(t, "This is the commit Title", m.Title)
-	assert.Equal(t, "And the body\n\n\nwith multiple lines", m.Body)
+	assert.Equal(t, "And the body\n\n\nwith multiple lines\n\nand a link http://maiao.foo", m.Body)
 	assert.Equal(t, map[string]string{"Header": "bla"}, m.Headers)
 }
 


### PR DESCRIPTION
With the current (naive) commit message parser, any line that includes a
colon (:) will basically be consider a HEADER. That becomes a problem if
you try to include an HTTP link in your commit message. It will be
consider a HEADER and the removed from the final Pull Request message.

For example, if your commit message was:
```
Fixed critical security vulnerability

Vulnerability reported [here](http://www.maiao.com)

As you can read in the previous link it is really severe
```

Maiao will craft a PR that will read:
```
Fixed critical security vulnerability

As you can read in the previous link it is really severe
```

Leaving a broken message

Proposed solution
----------------
It is kinda of naive as well. It assumes that, in a header, the colon : will
NEVER be followed by an slash /