### PR TITLE
Better support for Github Enterprise

### DIFF
--- a/pkg/github/credentials.go
+++ b/pkg/github/credentials.go
@@ -14,6 +14,7 @@ var DefaultCredentialGetter credentials.CredentialGetter = credentials.ChainCred
 
 var GitHubEnterpriseCredentialGetter credentials.CredentialGetter = credentials.ChainCredentialGetter([]credentials.CredentialGetter{
 	&credentials.EnvToken{PasswordKey: "GITHUB_ENTERPRISE_TOKEN"},
+	&credentials.EnvToken{PasswordKey: "GITHUB_TOKEN"},
 	&credentials.Netrc{},
 	&credentials.GitCredentials{GitPath: "git"},
 })

--- a/pkg/github/credentials.go
+++ b/pkg/github/credentials.go
@@ -11,3 +11,9 @@ var DefaultCredentialGetter credentials.CredentialGetter = credentials.ChainCred
 	&credentials.Netrc{},
 	&credentials.GitCredentials{GitPath: "git"},
 })
+
+var GitHubEnterpriseCredentialGetter credentials.CredentialGetter = credentials.ChainCredentialGetter([]credentials.CredentialGetter{
+	&credentials.EnvToken{PasswordKey: "GITHUB_ENTERPRISE_TOKEN"},
+	&credentials.Netrc{},
+	&credentials.GitCredentials{GitPath: "git"},
+})

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -52,6 +52,11 @@ func NewClient(domain string) (*github.Client, error) {
 
 func getGithubToken(domain string) (string, error) {
 	creds, err := DefaultCredentialGetter.CredentialForHost(domain)
+
+	if domain != "github.com" {
+		creds, err = GitHubEnterpriseCredentialGetter.CredentialForHost(domain)
+	}
+
 	if err != nil {
 		return "", err
 	}

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -1,22 +1,33 @@
 package gh
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/adevinta/maiao/pkg/credentials"
 	"github.com/adevinta/maiao/pkg/system"
+	"github.com/stretchr/testify/assert"
 )
 
-func setCredentialStore(c credentials.CredentialGetter) {
+func setDefaultCredentialStore(c credentials.CredentialGetter) {
 	DefaultCredentialGetter = c
+}
+
+func setEnterpriseCredentialStore(c credentials.CredentialGetter) {
+	GitHubEnterpriseCredentialGetter = c
 }
 
 type TestCredentialGetter struct {
 	Credentials *credentials.Credentials
 	Error       error
 	Check       func()
+}
+
+type GithubTokenTestData struct {
+	setCredentialStore  func(credentials.CredentialGetter)
+	domain              string
+	environmentVariable string
 }
 
 func (c *TestCredentialGetter) CredentialForHost(string) (*credentials.Credentials, error) {
@@ -26,45 +37,65 @@ func (c *TestCredentialGetter) CredentialForHost(string) (*credentials.Credentia
 	return c.Credentials, c.Error
 }
 
-func TestGetGitHubToken(t *testing.T) {
+func sprintf(original string, githubGithubTokenTestData GithubTokenTestData) string {
+	return fmt.Sprintf(original+" (domain: '%s', environment variable: '%s'", githubGithubTokenTestData.domain, githubGithubTokenTestData.environmentVariable)
+}
+
+func GitHubTokenTest(t *testing.T, githubTokenTestData GithubTokenTestData) {
 	t.Cleanup(system.Reset)
-	os.Unsetenv("GITHUB_TOKEN")
+	os.Unsetenv(githubTokenTestData.environmentVariable)
 	creds := &TestCredentialGetter{}
-	defer setCredentialStore(DefaultCredentialGetter)
-	setCredentialStore(creds)
-	t.Run("when username and password are provided, password is used as token", func(t *testing.T) {
+	defer githubTokenTestData.setCredentialStore(DefaultCredentialGetter)
+	githubTokenTestData.setCredentialStore(creds)
+	t.Run(sprintf("when username and password are provided, password is used as token", githubTokenTestData), func(t *testing.T) {
 		defer func(c *credentials.Credentials) { creds.Credentials = c }(creds.Credentials)
 		creds.Credentials = &credentials.Credentials{
 			Username: "user",
 			Password: "api key",
 		}
-		token, err := getGithubToken("test.domain.tld")
+		token, err := getGithubToken(githubTokenTestData.domain)
 		assert.NoError(t, err)
 		assert.Equal(t, "api key", token)
 	})
-	t.Run("when username only is provided, username is used as token", func(t *testing.T) {
+	t.Run(sprintf("when username only is provided, username is used as token", githubTokenTestData), func(t *testing.T) {
 		defer func(c *credentials.Credentials) { creds.Credentials = c }(creds.Credentials)
 		creds.Credentials = &credentials.Credentials{
 			Username: "user",
 		}
-		token, err := getGithubToken("test.domain.tld")
+		token, err := getGithubToken(githubTokenTestData.domain)
 		assert.NoError(t, err)
 		assert.Equal(t, "user", token)
 	})
-	t.Run("when password only is provided, password is used as token", func(t *testing.T) {
+	t.Run(sprintf("when password only is provided, password is used as token", githubTokenTestData), func(t *testing.T) {
 		defer func(c *credentials.Credentials) { creds.Credentials = c }(creds.Credentials)
 		creds.Credentials = &credentials.Credentials{
 			Password: "api key",
 		}
-		token, err := getGithubToken("test.domain.tld")
+		token, err := getGithubToken(githubTokenTestData.domain)
 		assert.NoError(t, err)
 		assert.Equal(t, "api key", token)
 	})
-	t.Run("when nothing is provided, an error is returned", func(t *testing.T) {
+	t.Run(sprintf("when nothing is provided, an error is returned", githubTokenTestData), func(t *testing.T) {
 		defer func(c *credentials.Credentials) { creds.Credentials = c }(creds.Credentials)
 		creds.Credentials = &credentials.Credentials{}
-		token, err := getGithubToken("test.domain.tld")
+		token, err := getGithubToken(githubTokenTestData.domain)
 		assert.Error(t, err)
 		assert.Equal(t, "", token)
+	})
+}
+
+func TestGetGitHubDotComToken(t *testing.T) {
+	GitHubTokenTest(t, GithubTokenTestData{
+		setCredentialStore:  setDefaultCredentialStore,
+		domain:              "github.com",
+		environmentVariable: "GITHUB_TOKEN",
+	})
+}
+
+func TestGetGitHubEnterpriseToken(t *testing.T) {
+	GitHubTokenTest(t, GithubTokenTestData{
+		setCredentialStore:  setEnterpriseCredentialStore,
+		domain:              "test.domain.tld",
+		environmentVariable: "GITHUB_ENTERPRISE_TOKEN",
 	})
 }


### PR DESCRIPTION
Background
=====

People may use Maiao for [Github Enterprise][ghe] and github.com.

Problem
=====

Currently, the burden of changing the `GITHUB_TOKEN` environment variable
is on the user. If the user doesn't want to set a `.netrc` file for
different hosts, they need to things such as
`export GITHUB_TOKEN=$GITHUB_ENTERPRISE_TOKEN`, which is not very friendly.

Goal
=====

To support domains out of `github.com` through the `GITHUB_ENTERPRISE_TOKEN`
environment variable.

Caveats
=====

To avoid breaking changes with the current API, there's a fallback for
domains other than `github.com` to search for the `GITHUB_TOKEN`.

[ghe]: https://github.com/enterprise
<details>
<summary>
Committer details
</summary>
Local-Branch: main
</details>