### PR TITLE
Fix: remove some debug lines

### DIFF
--- a/pkg/git/message.go
+++ b/pkg/git/message.go
@@ -36,7 +36,6 @@ func Parse(message string) *Message {
 	for scanner.Scan() {
 		line := scanner.Text()
 		parts := headerRe.FindStringSubmatch(line)
-		fmt.Println(parts)
 		switch len(parts) {
 		case 0, 1, 2:
 			l.WithField("line", line).Trace("line does not contain header")


### PR DESCRIPTION

<details>
<summary>
Committer details
</summary>
Local-Branch: main
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Add support for system and pass keyrings (#19)
</summary>
In the current implementation, maiao uses unsecure storage for github
credentials. Either ~/.netrc or GITHUB_TOKEN environment variable.

This causes a security issue as the secrets are not protected and
available from anybody on the computer.

The goal of this commit is to rely on safer credential stores like
[pass], or the system keychain to store credentials.

Those credential stores uses non-trivial format and hence, implement a
logic to retrieve login details to the user prior to storing them in the
credentials store.

[pass]: https://www.passwordstore.org
</details>
</details>
</details>