### PR TITLE
Move hook path computation to the git lib

### DIFF
--- a/pkg/git/hook.go
+++ b/pkg/git/hook.go
@@ -1,0 +1,45 @@
+package git
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/adevinta/maiao/pkg/system"
+)
+
+const (
+	CommitMsgHook Hook = "commit-msg"
+)
+
+type Hook string
+
+const (
+	ApplyPatchMsgHook    Hook = "applypatch-msg"
+	PostApplyPatchHook   Hook = "post-applypatch"
+	PostCheckoutHook     Hook = "post-checkout"
+	PostCommitHook       Hook = "post-commit"
+	PostMergeHook        Hook = "post-merge"
+	PostRewriteHook      Hook = "post-rewrite"
+	PrepareCommitMsgHook Hook = "prepare-commit-msg"
+	PreApplyPatchHook    Hook = "pre-applypatch"
+	PreAutoGCHook        Hook = "pre-auto-gc"
+	PrePushHook          Hook = "pre-push"
+	PreRebaseHook        Hook = "pre-rebase"
+)
+
+func HookPath(gitDir string, hook Hook) string {
+	commonDirPath := filepath.Join(gitDir, "commondir")
+	_, err := system.DefaultFileSystem.Stat(commonDirPath)
+	if err == nil {
+		fd, err := system.DefaultFileSystem.Open(commonDirPath)
+		if err == nil {
+			defer fd.Close()
+			bytes, err := ioutil.ReadAll(fd)
+			if err == nil {
+				gitDir = filepath.Join(gitDir, strings.TrimSpace(string(bytes)))
+			}
+		}
+	}
+	return filepath.Join(gitDir, "hooks", string(hook))
+}

--- a/pkg/git/hook_test.go
+++ b/pkg/git/hook_test.go
@@ -1,0 +1,51 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHookPath(t *testing.T) {
+	repo, err := os.MkdirTemp("", "maiao-test-repo")
+	require.NoError(t, err)
+	worktree, err := os.MkdirTemp("", "maiao-test-worktree")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.RemoveAll(repo)
+		os.RemoveAll(worktree)
+	})
+
+	cmd(t, "git", "-C", repo, "init")
+	cmd(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "initial commit")
+	cmd(t, "git", "-C", repo, "worktree", "add", worktree)
+
+	// Use show toplevel as tempfiles on mac may be in /var/folders/... while mounted volumes are in /private/var/folders/...
+	// Internally, when creating worktrees, git uses the toplevel to point to the worktree dir
+	// Hint it to do the same
+	repoGitDir, err := FindGitDir(cmdOutput(t, "git", "-C", repo, "rev-parse", "--show-toplevel"))
+	require.NoError(t, err)
+	worktreeGitDir, err := FindGitDir(cmdOutput(t, "git", "-C", worktree, "rev-parse", "--show-toplevel"))
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		filepath.Join(repoGitDir, "hooks", "commit-msg"),
+		HookPath(
+			filepath.Join(cmdOutput(t, "git", "-C", repo, "rev-parse", "--show-toplevel"), ".git"),
+			CommitMsgHook,
+		),
+	)
+
+	assert.Equal(
+		t,
+		filepath.Join(repoGitDir, "hooks", "commit-msg"),
+		HookPath(
+			worktreeGitDir,
+			CommitMsgHook,
+		),
+	)
+}


### PR DESCRIPTION
In order to enable the capability of injecting the PullRequest template
in the commit message, we will need a similar hook path detection logic
to propose auto installation.

Having the HookPath function in the git module will help us do so.
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Add pre-commit-message hook (#28)
</summary>
In many cases, our GitHub users have PullRequest templates in their
repositories to guide users toward creating better quality PRs.

When using maiao, this behaviour is lost and the pull request templates
are not used.

With maiao's philosophy that every single (small) commit turns into a
Pull Request, this commit implements an optional and experimental hook
to insert the pull request template.

This injestion is skept when using `git commit -m "my-message"` as git
won't launch any editor with interactions with the user.
</details>
</details>
</details>