### PR TITLE
[need #27] Add pre-commit-message hook

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -107,6 +107,12 @@ func NewCommand() *cobra.Command {
 			RunE:   rebaseEditor,
 			Hidden: true,
 		},
+		&cobra.Command{
+			Use:    "prepare-commit-message",
+			Short:  "Initialises a commit message with Pull Request templates",
+			RunE:   prepare_commit_message,
+			Hidden: true,
+		},
 	)
 	rootCmd.AddCommand()
 	return rootCmd

--- a/pkg/cmd/install.go
+++ b/pkg/cmd/install.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
+	"os"
+
+	"github.com/adevinta/maiao/pkg/committemplate"
 	"github.com/adevinta/maiao/pkg/gerrit"
 	lgit "github.com/adevinta/maiao/pkg/git"
+	"github.com/spf13/cobra"
 )
 
 func install(cmd *cobra.Command, args []string) error {
@@ -14,6 +17,12 @@ func install(cmd *cobra.Command, args []string) error {
 	err = gerrit.Install(gitDir)
 	if err != nil {
 		return err
+	}
+	if os.Getenv("MAIAO_EXPERIMENTAL_COMMIT_TEMPLATE") == "true" {
+		err = committemplate.Install(gitDir)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/cmd/prepare_commit_message.go
+++ b/pkg/cmd/prepare_commit_message.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/adevinta/maiao/pkg/committemplate"
+	"github.com/adevinta/maiao/pkg/log"
+	"github.com/go-git/go-git/v5"
+	"github.com/spf13/cobra"
+)
+
+func prepare_commit_message(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("missing required commit message file path")
+	}
+	if len(args) >= 3 {
+		// This is an ammend
+		// See official git documentation: https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
+		// The prepare-commit-msg hook is run before the commit message editor is fired up but after
+		// the default message is created. It lets you edit the default message before the commit author sees it.
+		// This hook takes a few parameters: the path to the file that holds the commit message so far,
+		// the type of commit, and the commit SHA-1 if this is an amended commit
+		log.Logger.Debug("this is an ammend commit, skipping")
+		return nil
+	}
+	repo, err := git.PlainOpenWithOptions(cmd.Flag("path").Value.String(), &git.PlainOpenOptions{DetectDotGit: true})
+	if err != nil {
+		return err
+	}
+	err = committemplate.Prepare(context.Background(), repo, args[0])
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/committemplate/pr.go
+++ b/pkg/committemplate/pr.go
@@ -1,0 +1,134 @@
+package committemplate
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/adevinta/maiao/pkg/git"
+	lgit "github.com/adevinta/maiao/pkg/git"
+	"github.com/adevinta/maiao/pkg/log"
+	"github.com/adevinta/maiao/pkg/system"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+)
+
+type Interface interface {
+	Installed() bool
+	Install() error
+}
+
+type PrepareCommitMessageHook struct {
+	gitDir string
+}
+
+// Installed returned wether the gerrit hook message is installed
+func (g *PrepareCommitMessageHook) Installed() bool {
+	path := git.HookPath(g.gitDir, git.PrepareCommitMsgHook)
+	_, err := system.DefaultFileSystem.Stat(path)
+	log.Logger.WithFields(logrus.Fields{
+		"gitDir":                       g.gitDir,
+		"prepare-commit-msg path":      path,
+		"prepare-commit-msg installed": err == nil,
+	}).Debugf("err: %v", err)
+	return err == nil
+}
+
+// Install installs the gerrit prepare commit message hook in a repository
+func (g *PrepareCommitMessageHook) Install() error {
+	path := git.HookPath(g.gitDir, git.PrepareCommitMsgHook)
+
+	l := log.Logger.WithFields(logrus.Fields{
+		"gitDir":                  g.gitDir,
+		"prepare-commit-msg path": path,
+	})
+	l.Debug("creating 'prepare-commit-msg' hook")
+	fd, err := system.DefaultFileSystem.Create(path)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("failed to create prepare commit message hook file %s", path))
+	}
+	defer fd.Close()
+	_, err = fd.Write([]byte(`#!/bin/sh
+# This hook has been installed by maiao
+# see https://github.com/adevinta/maiao
+# This hook is used to add a pull request template to the commit message
+exec git-review prepare-commit-message "$@"
+`))
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("failed to create prepare commit message hook file %s", path))
+	}
+
+	err = system.DefaultFileSystem.Chmod(path, 0755)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("failed to set execution rights to message hook file %s", path))
+	}
+	return nil
+}
+
+// Installed returned wether the gerrit hook message is installed
+func Installed(gitDir string) bool {
+	g := &PrepareCommitMessageHook{gitDir}
+	return g.Installed()
+}
+
+// Install installs the gerrit prepare commit message hook in a repository
+func Install(gitDir string) error {
+	g := &PrepareCommitMessageHook{gitDir}
+	return g.Install()
+}
+
+func Prepare(ctx context.Context, repo lgit.Repository, path string) error {
+	wt, err := repo.Worktree()
+	if err != nil {
+		return err
+	}
+	root := wt.Filesystem.Root()
+	templatePath := filepath.Join(root, ".github", "pull_request_template.md")
+	ctx = log.WithContextFields(ctx, logrus.Fields{"template-path": templatePath})
+	_, err = system.DefaultFileSystem.Stat(templatePath)
+	if os.IsNotExist(err) {
+		log.Logger.WithContext(ctx).Debugf("no pull request template found")
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	instructions, err := afero.ReadFile(system.DefaultFileSystem, path)
+	if err != nil {
+		return err
+	}
+	cfg, err := repo.Config()
+	if err != nil {
+		return err
+	}
+	for i := 0; i < len(instructions); i++ {
+		if instructions[i] == '\n' {
+			continue
+		}
+		if instructions[i] == cfg.Core.CommentChar[0] {
+			break
+		}
+		log.Logger.WithContext(ctx).Debugf("commit message already contains a message, skipping")
+		return nil
+	}
+
+	prTemplate, err := afero.ReadFile(system.DefaultFileSystem, templatePath)
+	if err != nil {
+		return err
+	}
+	fd, err := system.DefaultFileSystem.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer fd.Close()
+	// Create a space for the commit title and split commit title and message by one empty line
+	fd.Write([]byte("\n\n"))
+	_, err = fd.Write(append(prTemplate, instructions...))
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/committemplate/pr.go
+++ b/pkg/committemplate/pr.go
@@ -108,6 +108,9 @@ func Prepare(ctx context.Context, repo lgit.Repository, path string) error {
 		if instructions[i] == '\n' {
 			continue
 		}
+		if len(cfg.Core.CommentChar) == 0 {
+			cfg.Core.CommentChar = "#"
+		}
 		if instructions[i] == cfg.Core.CommentChar[0] {
 			break
 		}

--- a/pkg/committemplate/pr_test.go
+++ b/pkg/committemplate/pr_test.go
@@ -1,0 +1,211 @@
+package committemplate
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	lgit "github.com/adevinta/maiao/pkg/git"
+	"github.com/adevinta/maiao/pkg/system"
+	"github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fsStub struct {
+	billy.Filesystem
+	rootFunc func() string
+}
+
+func (f *fsStub) Root() string {
+	if f.rootFunc == nil {
+		return ""
+	}
+	return f.rootFunc()
+}
+
+type repoStub struct {
+	lgit.Repository
+	workteeFunc func() (*git.Worktree, error)
+	configFunc  func() (*config.Config, error)
+}
+
+func (r *repoStub) Worktree() (*git.Worktree, error) {
+	if r.workteeFunc == nil {
+		return nil, errors.New("Worktree not implemented")
+	}
+	return r.workteeFunc()
+}
+
+func (r *repoStub) Config() (*config.Config, error) {
+	if r.configFunc == nil {
+		return nil, errors.New("Config not implemented")
+	}
+	return r.configFunc()
+}
+
+func TestInstalled(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	system.DefaultFileSystem = fs
+	t.Cleanup(system.Reset)
+
+	hookPath := "/path/to/git/dir/hooks/prepare-commit-msg"
+	gitDir := "/path/to/git/dir"
+	g := &PrepareCommitMessageHook{
+		gitDir: gitDir,
+	}
+
+	// Hook not installed
+	fs.Remove(hookPath)
+	assert.False(t, g.Installed())
+
+	// Hook installed
+	fs.MkdirAll(filepath.Dir(hookPath), 0755)
+	f, err := fs.Create(hookPath)
+	assert.NoError(t, err)
+	f.Close()
+	assert.True(t, g.Installed())
+}
+
+func TestInstall(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	system.DefaultFileSystem = fs
+	t.Cleanup(system.Reset)
+
+	gitDir := "/path/to/git/dir"
+
+	g := &PrepareCommitMessageHook{
+		gitDir: gitDir,
+	}
+
+	err := g.Install()
+	assert.NoError(t, err)
+
+	hookPath := filepath.Join(gitDir, "hooks", "prepare-commit-msg")
+	exists, err := afero.Exists(fs, hookPath)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+
+	hookContents, err := afero.ReadFile(fs, hookPath)
+	assert.NoError(t, err)
+	expectedContents := `#!/bin/sh
+# This hook has been installed by maiao
+# see https://github.com/adevinta/maiao
+# This hook is used to add a pull request template to the commit message
+exec git-review prepare-commit-message "$@"
+`
+	assert.Equal(t, expectedContents, string(hookContents))
+}
+
+func TestPrepare(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	system.DefaultFileSystem = fs
+	t.Cleanup(system.Reset)
+
+	repo := &repoStub{
+		configFunc: func() (*config.Config, error) {
+			cfg := config.NewConfig()
+			cfg.Core.CommentChar = "#"
+			return cfg, nil
+		},
+		workteeFunc: func() (*git.Worktree, error) {
+			return &git.Worktree{
+				Filesystem: &fsStub{
+					rootFunc: func() string {
+						return "/path/to/git/dir"
+					},
+				},
+			}, nil
+		},
+	}
+
+	t.Run("When the PR template does not exist", func(t *testing.T) {
+		t.Run("When the commit message file does not exist", func(t *testing.T) {
+			assert.NoError(t, Prepare(context.Background(), repo, "/path/to/git/dir/.git/COMMIT_MSG"))
+		})
+		t.Run("When the commit message file does not exist", func(t *testing.T) {
+			fd, err := fs.Create("/path/to/git/dir/.git/COMMIT_MSG")
+			require.NoError(t, err)
+			_, err = fd.Write([]byte("commit message"))
+			require.NoError(t, err)
+			require.NoError(t, fd.Close())
+			assert.NoError(t, Prepare(context.Background(), repo, "/path/to/git/dir/.git/COMMIT_MSG"))
+		})
+	})
+
+	t.Run("When the PR template exists", func(t *testing.T) {
+		fs = afero.NewMemMapFs()
+		system.DefaultFileSystem = fs
+		fd, err := fs.Create("/path/to/git/dir/.github/pull_request_template.md")
+		require.NoError(t, err)
+		_, err = fd.Write([]byte("PR template"))
+		require.NoError(t, err)
+		require.NoError(t, fd.Close())
+
+		t.Run("When the commit message file does not exist", func(t *testing.T) {
+			assert.Error(t, Prepare(context.Background(), repo, "/path/to/git/dir/.git/COMMIT_MSG"))
+		})
+		t.Run("When the commit message file does not exist", func(t *testing.T) {
+			fd, err := fs.Create("/path/to/git/dir/.git/COMMIT_MSG")
+			require.NoError(t, err)
+			_, err = fd.Write([]byte("\n# instructions for commit message"))
+			require.NoError(t, err)
+			require.NoError(t, fd.Close())
+			assert.NoError(t, Prepare(context.Background(), repo, "/path/to/git/dir/.git/COMMIT_MSG"))
+		})
+	})
+
+	testPrepareCommitMessageContent(t, "#", "\n# instructions for commit message", "PR template", "\n\nPR template\n# instructions for commit message")
+	testPrepareCommitMessageContent(t, "#", " pre-defined commit message\n# instructions for commit message", "PR template", " pre-defined commit message\n# instructions for commit message")
+	testPrepareCommitMessageContent(t, "^", " pre-defined commit message\n^ instructions for commit message", "PR template", " pre-defined commit message\n^ instructions for commit message")
+}
+
+func testPrepareCommitMessageContent(t *testing.T, commentChar, messageContent, templateContent, expectedContent string) {
+	t.Helper()
+	fs := afero.NewMemMapFs()
+	system.DefaultFileSystem = fs
+	t.Cleanup(system.Reset)
+
+	repo := &repoStub{
+		configFunc: func() (*config.Config, error) {
+			cfg := config.NewConfig()
+			cfg.Core.CommentChar = commentChar
+			return cfg, nil
+		},
+		workteeFunc: func() (*git.Worktree, error) {
+			return &git.Worktree{
+				Filesystem: &fsStub{
+					rootFunc: func() string {
+						return "/path/to/git/dir"
+					},
+				},
+			}, nil
+		},
+	}
+
+	fd, err := fs.Create("/path/to/git/dir/.git/COMMIT_MSG")
+	require.NoError(t, err)
+	_, err = fd.Write([]byte(messageContent))
+	require.NoError(t, err)
+	require.NoError(t, fd.Close())
+
+	fd, err = fs.Create("/path/to/git/dir/.github/pull_request_template.md")
+	require.NoError(t, err)
+	_, err = fd.Write([]byte(templateContent))
+	require.NoError(t, err)
+	require.NoError(t, fd.Close())
+
+	assert.NoError(t, Prepare(context.Background(), repo, "/path/to/git/dir/.git/COMMIT_MSG"))
+
+	fd, err = fs.Open("/path/to/git/dir/.git/COMMIT_MSG")
+	require.NoError(t, err)
+	content, err := afero.ReadAll(fd)
+	require.NoError(t, err)
+	require.NoError(t, fd.Close())
+
+	assert.Equal(t, expectedContent, string(content))
+}

--- a/pkg/git/hook.go
+++ b/pkg/git/hook.go
@@ -1,0 +1,45 @@
+package git
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/adevinta/maiao/pkg/system"
+)
+
+const (
+	CommitMsgHook Hook = "commit-msg"
+)
+
+type Hook string
+
+const (
+	ApplyPatchMsgHook    Hook = "applypatch-msg"
+	PostApplyPatchHook   Hook = "post-applypatch"
+	PostCheckoutHook     Hook = "post-checkout"
+	PostCommitHook       Hook = "post-commit"
+	PostMergeHook        Hook = "post-merge"
+	PostRewriteHook      Hook = "post-rewrite"
+	PrepareCommitMsgHook Hook = "prepare-commit-msg"
+	PreApplyPatchHook    Hook = "pre-applypatch"
+	PreAutoGCHook        Hook = "pre-auto-gc"
+	PrePushHook          Hook = "pre-push"
+	PreRebaseHook        Hook = "pre-rebase"
+)
+
+func HookPath(gitDir string, hook Hook) string {
+	commonDirPath := filepath.Join(gitDir, "commondir")
+	_, err := system.DefaultFileSystem.Stat(commonDirPath)
+	if err == nil {
+		fd, err := system.DefaultFileSystem.Open(commonDirPath)
+		if err == nil {
+			defer fd.Close()
+			bytes, err := ioutil.ReadAll(fd)
+			if err == nil {
+				gitDir = filepath.Join(gitDir, strings.TrimSpace(string(bytes)))
+			}
+		}
+	}
+	return filepath.Join(gitDir, "hooks", string(hook))
+}

--- a/pkg/git/hook_test.go
+++ b/pkg/git/hook_test.go
@@ -1,0 +1,51 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHookPath(t *testing.T) {
+	repo, err := os.MkdirTemp("", "maiao-test-repo")
+	require.NoError(t, err)
+	worktree, err := os.MkdirTemp("", "maiao-test-worktree")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.RemoveAll(repo)
+		os.RemoveAll(worktree)
+	})
+
+	cmd(t, "git", "-C", repo, "init")
+	cmd(t, "git", "-C", repo, "commit", "--allow-empty", "-m", "initial commit")
+	cmd(t, "git", "-C", repo, "worktree", "add", worktree)
+
+	// Use show toplevel as tempfiles on mac may be in /var/folders/... while mounted volumes are in /private/var/folders/...
+	// Internally, when creating worktrees, git uses the toplevel to point to the worktree dir
+	// Hint it to do the same
+	repoGitDir, err := FindGitDir(cmdOutput(t, "git", "-C", repo, "rev-parse", "--show-toplevel"))
+	require.NoError(t, err)
+	worktreeGitDir, err := FindGitDir(cmdOutput(t, "git", "-C", worktree, "rev-parse", "--show-toplevel"))
+	require.NoError(t, err)
+
+	assert.Equal(
+		t,
+		filepath.Join(repoGitDir, "hooks", "commit-msg"),
+		HookPath(
+			filepath.Join(cmdOutput(t, "git", "-C", repo, "rev-parse", "--show-toplevel"), ".git"),
+			CommitMsgHook,
+		),
+	)
+
+	assert.Equal(
+		t,
+		filepath.Join(repoGitDir, "hooks", "commit-msg"),
+		HookPath(
+			worktreeGitDir,
+			CommitMsgHook,
+		),
+	)
+}


### PR DESCRIPTION
In many cases, our GitHub users have PullRequest templates in their
repositories to guide users toward creating better quality PRs.

When using maiao, this behaviour is lost and the pull request templates
are not used.

With maiao's philosophy that every single (small) commit turns into a
Pull Request, this commit implements an optional and experimental hook
to insert the pull request template.

This injestion is skept when using `git commit -m "my-message"` as git
won't launch any editor with interactions with the user.
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Parent changes
</summary>
<details>
<summary>
Move hook path computation to the git lib (#27)
</summary>
In order to enable the capability of injecting the PullRequest template
in the commit message, we will need a similar hook path detection logic
to propose auto installation.

Having the HookPath function in the git module will help us do so.
</details>
</details>
</details>