### PR TITLE
Fix github topic link

### DIFF
--- a/pkg/api/github.go
+++ b/pkg/api/github.go
@@ -114,8 +114,12 @@ func (g *GitHub) DefaultBranch(ctx context.Context) string {
 }
 
 // LinkedTopicIssues returns the search URL for linked issues
-func (g *GitHub) LinkedTopicIssues(topic string) string {
-	return `https://` + g.Host + `/search?q=type%3Apr+%22Topic%3A+` + url.QueryEscape(topic) + `%22&type=Issues`
+func (g *GitHub) LinkedTopicIssues(topicSearchString string) string {
+	values := url.Values{}
+	values.Add("q", fmt.Sprintf(`is:pr is:open "%s"`, topicSearchString))
+	values.Add("type", "issues")
+	values.Encode()
+	return `https://` + g.Host + `/search?` + values.Encode()
 }
 
 // NewGitHubUpserter instanciates an upserter that uses the github API to create and update pull requests

--- a/pkg/api/github_test.go
+++ b/pkg/api/github_test.go
@@ -353,6 +353,17 @@ func TestGitHubUpsert(t *testing.T) {
 
 }
 
+func TestLinkedTopicIssues(t *testing.T) {
+	g := GitHub{
+		Host: "github.com",
+	}
+	assert.Equal(
+		t,
+		"https://github.com/search?q=is%3Apr+is%3Aopen+%22topic-sha%22&type=issues",
+		g.LinkedTopicIssues("topic-sha"),
+	)
+}
+
 // get all logs when running tests
 func init() {
 	log.Logger.SetLevel(logrus.DebugLevel)

--- a/pkg/api/pullRequester.go
+++ b/pkg/api/pullRequester.go
@@ -16,7 +16,7 @@ type PullRequester interface {
 	Update(context.Context, *PullRequest, PullRequestOptions) (*PullRequest, error)
 	// Ensure ensures one and only one pull request exists for the given head
 	Ensure(context.Context, PullRequestOptions) (*PullRequest, bool, error)
-	LinkedTopicIssues(topic string) string
+	LinkedTopicIssues(topicSearchString string) string
 	DefaultBranch(context.Context) string
 }
 

--- a/pkg/maiao/message.go
+++ b/pkg/maiao/message.go
@@ -1,6 +1,7 @@
 package maiao
 
 import (
+	"crypto/sha1"
 	"fmt"
 	"strings"
 
@@ -23,11 +24,15 @@ func details(body []string, summary string) []string {
 }
 
 func topicDetails(prAPI api.PullRequester, topic string) []string {
+	sha := sha1.New()
+	sha.Write([]byte("topic: "))
+	sha.Write([]byte(topic))
+	topicSha := fmt.Sprintf("%x", sha.Sum(nil))
 	return details(
 		[]string{
 			"This change is part of a broader topic that can be in multiple repositories.",
 			"<br/>",
-			`Topic: <a href="` + prAPI.LinkedTopicIssues(topic) + `">` + topic + `</a>`,
+			fmt.Sprintf(`Topic: <a href="%s" searchSha="%v">%s</a>`, prAPI.LinkedTopicIssues(topicSha), topicSha, topic),
 		},
 		"Broader related changes",
 	)

--- a/pkg/maiao/message_test.go
+++ b/pkg/maiao/message_test.go
@@ -3,8 +3,8 @@ package maiao
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/adevinta/maiao/pkg/api"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDetailsSkipsMissingSummaries(t *testing.T) {
@@ -51,9 +51,23 @@ func TestTopicDetailsProvidesLink(t *testing.T) {
 			"</summary>",
 			"This change is part of a broader topic that can be in multiple repositories.",
 			"<br/>",
-			`Topic: <a href="https://github.company.example.com/search?q=type%3Apr+%22Topic%3A+some+topic%22&type=Issues">some topic</a>`,
+			`Topic: <a href="https://search.example.com/topic" searchSha="89889b28e9672bff47fa4286f4aff4a80e09eade">some topic</a>`,
 			"</details>",
 		},
-		topicDetails(&api.GitHub{Host: "github.company.example.com"}, "some topic"),
+		topicDetails(&linkedTopicIssuesFunc{
+			linkedTopicIssuesFunc: func(topicSearchString string) string {
+				assert.Equal(t, "89889b28e9672bff47fa4286f4aff4a80e09eade", topicSearchString)
+				return "https://search.example.com/topic"
+			},
+		}, "some topic"),
 	)
+}
+
+type linkedTopicIssuesFunc struct {
+	api.PullRequester
+	linkedTopicIssuesFunc func(topicSearchString string) string
+}
+
+func (l linkedTopicIssuesFunc) LinkedTopicIssues(topicSearchString string) string {
+	return l.linkedTopicIssuesFunc(topicSearchString)
 }


### PR DESCRIPTION
Context
---

Lately, the github search api has been changed and breaks the topic links

Problem
---

Previously, linking topic `my-feature` was showing any PR with results with the word feature that did not relate to this specific topic

Goals
---

- Update github search link to match the new GitHub search API
- Ensure that we match the exact maiao topic

Change-Id: I6e09b654f6f31d5f7795d585c680a9d2cb336441