### PR TITLE
Fix rebase when changeIDs are missing

### DIFF
--- a/pkg/maiao/review.go
+++ b/pkg/maiao/review.go
@@ -395,11 +395,11 @@ func extractChanges(ctx context.Context, repo lgit.Repository, base, head plumbi
 			}
 			changeID, ok := message.GetChangeID()
 			if !ok {
-				changes = append(changes, &change{
+				changes = append([]*change{{
 					commits: changeCommits,
 					head:    changeCommits[len(changeCommits)-1],
 					message: message,
-				})
+				}}, changes...)
 
 			} else {
 				changes = append([]*change{{


### PR DESCRIPTION
Context
---

When git-review is run a first time when the git hook is not installed,
maiao wil do 2 things:

1. suggest to install the git hook
2. perform a rebase so all commits are updated with a changeID

When establishing the list of commits, maiao walks through the log,
from the most recent to the oldest, starting from the repo HEAD
and ending with the remote HEAD.

Those commits are then added to the changes in the same order so they
can be used in the rebase TODO list in the relevant order.

Problem
---

The technique used to inject the changes differs whether there is a
changeID or not in the commit message.

If a changeID is present, the commit is added at the beginning of the
change list, ensuring an order from oldest to newest.
If now, the change ID is absent, the commit is added at the end of the
list, making an order from newest to oldest.

Concretely, if the local changes are:

* $sha1 A commit without changeID 1
* $sha2 A commit with a changeID 1
* $sha3 A commit without changeID 2
* $sha4 A commit with a changeID 2

They will bet rebased as following, which may cause rebase conflicts on
the way.

* $sha1 A commit without changeID 1
* $sha3 A commit without changeID 2
* $sha2 A commit with a changeID 1
* $sha4 A commit with a changeID 2

Goal
---

Fix this situation
<details>
<summary>
Committer details
</summary>
Local-Branch: main
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Add an option to create draft pull requests (#45)
</summary>
Backport original git-review flags
```
-w, --work-in-progress Send patch as work in progress for Gerrit versions >= 2.15
-W, --ready            Send patch that is already work in progress as ready for review. Gerrit versions >= 2.15
```

This behaviour is matched to GitHub Draft status
</details>
</details>
</details>