### PR TITLE
Bump go to 1.22

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.21
+        go-version: 1.22
 
     - name: Build
       run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/adevinta/maiao
 
-go 1.20
+go 1.22
 
 require (
 	github.com/99designs/keyring v1.2.2

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -1,10 +1,12 @@
 #! /bin/bash
 
+set -e
 
-GO111MODULE=off go get github.com/axw/gocov/gocov
-GO111MODULE=off go get github.com/AlekSi/gocov-xml
-GO111MODULE=off go get github.com/jstemmer/go-junit-report
+go install github.com/axw/gocov/gocov@latest
+go install github.com/AlekSi/gocov-xml@latest
+go install github.com/jstemmer/go-junit-report@latest
 
+set +e
 
 go test -v ./... -cover -covermode=count -coverprofile=profile.cov | tee /dev/stderr | go-junit-report > junit.xml
 exit_code=$?


### PR DESCRIPTION

<details>
<summary>
Committer details
</summary>
Local-Branch: main
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Add an option to create draft pull requests (#45)
</summary>
Backport original git-review flags
```
-w, --work-in-progress Send patch as work in progress for Gerrit versions >= 2.15
-W, --ready            Send patch that is already work in progress as ready for review. Gerrit versions >= 2.15
```

This behaviour is matched to GitHub Draft status
</details>
</details>
</details>