### PR TITLE
fix: invalid auth when using ssh

### DIFF
--- a/pkg/credentials/auth_method.go
+++ b/pkg/credentials/auth_method.go
@@ -1,14 +1,22 @@
 package credentials
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/adevinta/maiao/pkg/log"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	gitssh "github.com/go-git/go-git/v5/plumbing/transport/ssh"
+	"golang.org/x/crypto/ssh"
 )
 
 type GitAuth struct {
+	Endpoint    *transport.Endpoint
 	Credentials CredentialGetter
 }
+
+var _ transport.AuthMethod = &GitAuth{}
+var _ gitssh.AuthMethod = &GitAuth{}
 
 func (a *GitAuth) SetAuth(r *http.Request) {
 	creds, err := a.Credentials.CredentialForHost(r.Host)
@@ -17,6 +25,17 @@ func (a *GitAuth) SetAuth(r *http.Request) {
 		return
 	}
 	r.SetBasicAuth(creds.Username, creds.Password)
+}
+
+func (a *GitAuth) ClientConfig() (*ssh.ClientConfig, error) {
+	if a.Endpoint == nil {
+		return nil, errors.New("no endpoint found")
+	}
+	sshauthMethod, err := gitssh.DefaultAuthBuilder(a.Endpoint.User)
+	if err != nil {
+		return nil, err
+	}
+	return sshauthMethod.ClientConfig()
 }
 
 func (a *GitAuth) Name() string {


### PR DESCRIPTION
Since the go-git bump, the authmethod changed and when provided

It must now implement the ssh authmethod
<details>
<summary>
Committer details
</summary>
Local-Branch: main
</details>